### PR TITLE
Fix spelling mistakes in package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "gameId": "e84461aa105140b6b628d151e26c86cd",
   "title": "OrangeGames Fabrique Boilerplate",
   "version": "1.2.0",
-  "description": "This is a boiler plate version for OrangeGames HTML5 games, use it at your discression to make awesome games :D",
+  "description": "This is a boilerplate version for OrangeGames HTML5 games, use it at your discretion to make awesome games :D",
   "contributors": [
     {
       "name": "Ale Bles",


### PR DESCRIPTION
Simply fixing two spelling mistakes in the Node package.json description.